### PR TITLE
Use default instead of latest to specify toolkit version

### DIFF
--- a/src/main/g8/$script_name;format="Camel"$.scala
+++ b/src/main/g8/$script_name;format="Camel"$.scala
@@ -1,4 +1,4 @@
-//> using toolkit typelevel:latest
+//> using toolkit typelevel:default
 
 import cats.effect.*
 


### PR DESCRIPTION
Updates this template to correspond to documentation changes here: https://github.com/typelevel/toolkit/pull/165